### PR TITLE
Fix sorting of branches

### DIFF
--- a/state.go
+++ b/state.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"vbom.ml/util/sortorder"
+
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/google/go-github/github"
 	"github.com/lib/pq"
@@ -523,11 +525,15 @@ func bootstrap(ctx context.Context, db *sql.DB) error {
 		if err := scanner.Err(); err != nil {
 			return err
 		}
-		sort.Sort(sort.Reverse(sort.StringSlice(repos[i].releaseBranches)))
+		sortBranches(repos[i].releaseBranches)
 
 		if err := repos[i].refresh(db); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func sortBranches(branches []string) {
+	sort.Sort(sort.Reverse(sortorder.Natural(branches)))
 }

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortBranches(t *testing.T) {
+	x := []string{"release-2.1", "release-1.2", "release-19.1"}
+	sortBranches(x)
+	exp := []string{"release-19.1", "release-2.1", "release-1.2"}
+	if !reflect.DeepEqual(x, exp) {
+		t.Errorf("expected %v; got %v", exp, x)
+	}
+}


### PR DESCRIPTION
Use numeric sort to get the correct branch ordering. CC @knz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/benesch/backboard/1)
<!-- Reviewable:end -->
